### PR TITLE
Fixing travis script to use proper pixi.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 before_install:
-  - npm install pixi.js
+  - npm install pixi.js@^3.0.2
 node_js:
   - "0.10"


### PR DESCRIPTION
package.json declares ^3.0.2 as pixi peer dependency, but travis is trying to install the latest.